### PR TITLE
Update create_users_migration_spec.rb

### DIFF
--- a/spec/create_users_migration_spec.rb
+++ b/spec/create_users_migration_spec.rb
@@ -1,4 +1,4 @@
-require_relative '../db/migrate/20150916154312_create_users.rb''
+require_relative '../db/migrate/20150916154312_create_users.rb'
 
 require_relative 'spec_helper'
 


### PR DESCRIPTION
improper syntax causes an error when running tests